### PR TITLE
Remove material dependencies

### DIFF
--- a/pipeline-as-code/BC-testing.gocd.yaml
+++ b/pipeline-as-code/BC-testing.gocd.yaml
@@ -13,26 +13,10 @@ pipelines:
         auto_update: true
         branch: master
         destination: '#{bc_wrk_dir}'
-      docker-server:
-        git: https://git.gocd.io/git/gocd/docker-gocd-server
-        shallow_clone: false
-        auto_update: true
-        branch: master
-        destination: '#{server_wrk_dir}'
-      docker-agent:
-        git: https://git.gocd.io/git/gocd/docker-gocd-agent
-        shallow_clone: false
-        auto_update: true
-        branch: master
-        destination: '#{agent_wrk_dir}'
       upload:
         pipeline: upload-addons
         stage: upload-addons
         name: upload
-      upgrade:
-        pipeline: Upgrade-testing
-        stage: Upgrade_tests
-        name: upgrade
     stages:
     - defaultStage:
         fetch_materials: true
@@ -46,7 +30,7 @@ pipelines:
           defaultJob:
             timeout: 0
             environment_variables:
-              GO_VERSION: 19.3.0
+              GO_VERSION: 19.4.0
             elastic_profile_id: ecs-gocd-dev-build-dind-docker-compose
             tasks:
             - fetch:

--- a/pipeline-as-code/Upgrade-testing-with-addons.gocd.yaml
+++ b/pipeline-as-code/Upgrade-testing-with-addons.gocd.yaml
@@ -17,10 +17,6 @@ pipelines:
         auto_update: true
         branch: master
         destination: '#{working_dir}'
-      fresh_install:
-        pipeline: Installer-testing
-        stage: Fresh_install
-        name: fresh_install
       upload:
         pipeline: upload-addons
         stage: upload-addons

--- a/pipeline-as-code/migration-test.gocd.yaml
+++ b/pipeline-as-code/migration-test.gocd.yaml
@@ -17,10 +17,10 @@ pipelines:
         branch: master
         destination: '#{working_dir}'
         name: migration-test
-      installer-tests:
-        pipeline: Upgrade-testing
-        stage: Upgrade_tests
-        name: installer-tests
+      upload:
+        pipeline: upload-addons
+        stage: upload-addons
+        name: upload
     stages:
     - defaultStage:
         fetch_materials: true
@@ -40,7 +40,7 @@ pipelines:
                 is_file: true
                 source: addon_builds/addon_builds.json
                 destination: '#{working_dir}'
-                pipeline: upload-addons/Upgrade-testing
+                pipeline: upload-addons
                 stage: upload-addons
                 job: upload
                 artifact_origin: gocd


### PR DESCRIPTION
BC testing no longer builds the image, it pulls image from docker hub. So removed dependency on docker repos