### PR TITLE
Add enable tls flag to the go versions less than 20.2.0

### DIFF
--- a/lib/provision/Rakefile
+++ b/lib/provision/Rakefile
@@ -151,6 +151,9 @@ end
         sh ('unlink /usr/bin/java')
         sh ('ln -s -f /home/jdk-11/bin/java /usr/bin/java')
       end
+      if Gem::Version.new(version.split('-')[0]) < Gem::Version.new('20.2.0')
+        sh(%(echo "wrapper.java.additional.101=-Dgo.server.enable.tls=true"  >> /usr/share/go-server/wrapper-config/wrapper-properties.conf))
+      end
       chmod_R 0o755, '/vagrant/provision/filesystem/start-stop-gocd-server-agent.sh'
       sh("./vagrant/provision/filesystem/start-stop-gocd-server-agent.sh server start")
       server_status

--- a/pipeline-as-code/Upgrade-testing-with-addons.gocd.yaml
+++ b/pipeline-as-code/Upgrade-testing-with-addons.gocd.yaml
@@ -5,7 +5,7 @@ pipelines:
     label_template: ${COUNT}
     lock_behavior: none
     environment_variables:
-      UPGRADE_VERSIONS_LIST: 19.4.0-9155, 19.7.0-9567, 19.8.0-9915
+      UPGRADE_VERSIONS_LIST: 19.8.0-9915, 19.10.0-10357, 20.1.0-11114
       ADDON_DOWNLOAD_URL: https://extensions.gocd.org/addons/postgres/versions
     secure_variables:
       EXTENSIONS_USER: AES:cqVQG+A2MQsMNKa6gyZtZA==:s8oKl//qdXIbuZunTnW9IjffCctQTO1QkmuJxAg2ij1lFBEEpigmkGXTvG68kmmZ

--- a/pipeline-as-code/installer-tests.gocd.yaml
+++ b/pipeline-as-code/installer-tests.gocd.yaml
@@ -51,7 +51,7 @@ pipelines:
             timeout: 0
             run_instances: '5'
             environment_variables:
-              UPGRADE_VERSIONS_LIST: 19.4.0-9155, 19.7.0-9567, 19.8.0-9915
+              UPGRADE_VERSIONS_LIST: 19.8.0-9915, 19.10.0-10357, 20.1.0-11114
             elastic_profile_id: installers-testing
             tasks:
             - exec:


### PR DESCRIPTION
This is the validate upgrade scenarios when older servers were using default TLS for agent server communication